### PR TITLE
feat: Modify member API to use session authentication

### DIFF
--- a/src/main/java/com/example/schedule/controller/MemberController.java
+++ b/src/main/java/com/example/schedule/controller/MemberController.java
@@ -46,31 +46,29 @@ public class MemberController {
         return new ResponseEntity<>(memberResponseDto, HttpStatus.OK);
     }
 
-    @PatchMapping("/{id}")
+    @PatchMapping
     public ResponseEntity<MemberResponseDto> updateMember(
-            @PathVariable Long id,
             @Valid @RequestBody MemberUpdateRequestDto requestDto,
             HttpSession session
     ) {
-        MemberResponseDto memberResponseDto = memberService.updateMember(id, requestDto, session);
+        MemberResponseDto memberResponseDto = memberService.updateMember(requestDto, session);
 
         return new ResponseEntity<>(memberResponseDto, HttpStatus.OK);
     }
 
-    @PatchMapping("/{id}/password")
+    @PatchMapping("/password")
     public ResponseEntity<Void> updatePassword(
-            @PathVariable Long id,
             @Valid @RequestBody MemberPasswordRequestDto requestDto,
             HttpSession session
     ) {
-        memberService.updatePassword(id, requestDto.getOldPassword(), requestDto.getNewPassword(), session);
+        memberService.updatePassword(requestDto.getOldPassword(), requestDto.getNewPassword(), session);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteMember(@PathVariable Long id, HttpSession session) {
-        memberService.deleteMember(id, session);
+    @DeleteMapping
+    public ResponseEntity<Void> deleteMember(HttpSession session) {
+        memberService.deleteMember(session);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }


### PR DESCRIPTION
- 회원 수정 및 삭제 API에서 ID를 경로 변수로 받지 않고 세션에서 조회하도록 변경
- 회원 수정 시 본인 여부 확인 후 업데이트 수행
- 회원 삭제 시 세션에서 사용자 정보 조회 및 로그아웃 처리 추가
- 패스워드 변경 시 기존 패스워드 검증 후 암호화하여 저장